### PR TITLE
Add Object::GetTypeName() method

### DIFF
--- a/include/Object.hpp
+++ b/include/Object.hpp
@@ -17,6 +17,7 @@ namespace vwr
         [[nodiscard]] int32_t GetHashCode() const override;
         [[nodiscard]] std::string ToString() const override;
         [[nodiscard]] const std::type_info& GetType() const;
+        [[nodiscard]] std::string GetTypeName() const;
 
         [[nodiscard]] bool Equals(const IGetHashCode &obj) const;
         static bool Equals(const IGetHashCode &obj1, const IGetHashCode &obj2);

--- a/src/Object.cpp
+++ b/src/Object.cpp
@@ -1,15 +1,30 @@
 #include "Object.hpp"
 
+#if defined(__GNUC__) || defined(__GNUG__)
+#include <cxxabi.h>
+#endif
+
 int32_t vwr::Object::GetHashCode() const {
     return vwr::GetHashCode((int64_t)this);
 }
 
 std::string vwr::Object::ToString() const {
-    return GetType().name();
+    return GetTypeName();
 }
 
 const std::type_info& vwr::Object::GetType() const {
     return typeid(*this);
+}
+
+std::string vwr::Object::GetTypeName() const {
+#if defined(__GNUC__) || defined(__GNUG__)
+    return std::string(
+            abi::__cxa_demangle(
+                    GetType().name(), nullptr, nullptr, nullptr
+                    ));
+#else
+    return GetType().name();
+#endif
 }
 
 bool vwr::Object::Equals(const vwr::IGetHashCode &obj) const {


### PR DESCRIPTION
Provides compiler-dependant type name demangling
Preferred over Object::GetType().name()