### PR TITLE
Explicitly include <cstdint> for GCC-13

### DIFF
--- a/include/IGetHashCode.hpp
+++ b/include/IGetHashCode.hpp
@@ -1,6 +1,7 @@
 #ifndef VWRTK_CWEL_I_GET_HASHCODE_HPP
 #define VWRTK_CWEL_I_GET_HASHCODE_HPP
 
+#include <cstdint>
 #include <string>
 
 namespace vwr


### PR DESCRIPTION
GCC 13 no longer implicitly includes \<cstdint\>
https://gcc.gnu.org/gcc-13/porting_to.html